### PR TITLE
feat: use main project's ndkVersion if available

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,6 +53,10 @@ android {
 
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
+  if (rootProject.hasProperty("ndkPath")) {
+    ndkPath rootProject.ext.ndkPath
+  }
+
   if (rootProject.hasProperty("ndkVersion")) {
     ndkVersion rootProject.ext.ndkVersion
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,6 +53,10 @@ android {
 
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
+  if (rootProject.hasProperty("ndkVersion")) {
+    ndkVersion rootProject.ext.ndkVersion
+  }
+
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")


### PR DESCRIPTION
### Summary

This PR makes it possible for the lib to be built using main project's `ndkVersion` instead of using the hardcoded one and potentially leading to the developer needing to install a separate NDK just to build this lib.

### Test plan

- Install the lib in a project which has a `ndkVersion` defined in the main project
- ensure the lib is built using that `ndkVersion` instead of the one defined in the `gradle.properties` (TimezoneHermesFix_ndkVersion=27.1.12297006)
